### PR TITLE
pdf: Add rudiments for coordinate space handling

### DIFF
--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -133,7 +133,7 @@ impl CoordinateSpace {
 		};
 
 		let media_box: Vec<f64> = dictionary
-			.get("MediaBox".as_bytes())
+			.get(b"MediaBox")
 			.map(|object| match object {
 				Object::Array(array) => array
 					.iter()
@@ -148,7 +148,7 @@ impl CoordinateSpace {
 			.ok()
 			.unwrap();
 		let crop_box: Vec<f64> = dictionary
-			.get("CropBox".as_bytes())
+			.get(b"CropBox")
 			.map(|object| match object {
 				Object::Array(array) => array
 					.iter()


### PR DESCRIPTION
Performance is not as huge of a concern at this point, but I do want the core architecture to be able to parse PDF files as fast as possible. Slices/fixed-size arrays seem like the logical way to do that.  I'm sure that there will be optimizations to consider, but for now this is how I'll implement this.