### PR TITLE
pdf: Mark matrix in documentation as text

### DIFF
--- a/src/pdf.rs
+++ b/src/pdf.rs
@@ -100,7 +100,7 @@ pub struct CoordinateSpace {
 /// The parameters are specified left-to-right, so that the subscript-to-cell
 /// mapping is:
 ///
-/// ```
+/// ```text
 /// [  .0   .1  0.0 ]
 /// [  .2   .3  0.0 ]
 /// [  .4   .5  1.0 ]


### PR DESCRIPTION
This prevents rustdoc from evaluating it as code.  The `.0`, etc. entries are actually tuple subscript notation, which we don't really want to have evaluated by the Rust compiler when it's doing tests.